### PR TITLE
No 1.6? No problem

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -138,7 +138,7 @@ $(info $(space))
 $(info Please follow the machine setup instructions at)
 $(info $(space)$(space)$(space)$(space)https://source.android.com/source/download.html)
 $(info ************************************************************)
-$(error stop)
+#$(error stop)
 endif
 
 # Check for the correct version of javac


### PR DESCRIPTION
If you're not running pure Java 1.6 the build errors out. This allows building with different versions like 1.6.x
