### PR TITLE
Add flag to toggle block-based build

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1635,6 +1635,28 @@ ifneq ($(TARGET_UNIFIED_DEVICE),)
     endif
 endif
 
+ifneq ($(BLOCK_BASED_BUILD),0)
+ifneq ($(BLOCK_BASED_BUILD),1)
+ BLOCK_BASED_BUILD := 1
+endif
+endif
+
+ifeq ($(BLOCK_BASED_BUILD),0)
+$(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(DISTTOOLS)
+	@echo "$(OTA_FROM_TARGET_SCRIPT)" > $(PRODUCT_OUT)/ota_script_path
+	@echo "$(override_device)" > $(PRODUCT_OUT)/ota_override_device
+	@echo -e ${CL_YLW}"Package OTA:"${CL_RST}" $@"
+	$(hide) MKBOOTIMG=$(MKBOOTIMG) \
+	   $(OTA_FROM_TARGET_SCRIPT) -v \
+	   -p $(HOST_OUT) \
+	   -k $(KEY_CERT_PAIR) \
+	   --backup=$(backuptool) \
+	   --override_device=$(override_device) $(override_prop) \
+	   $(if $(OEM_OTA_CONFIG), -o $(OEM_OTA_CONFIG)) \
+	   $(BUILT_TARGET_FILES_PACKAGE) $@
+endif
+
+ifeq ($(BLOCK_BASED_BUILD),1)
 $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(DISTTOOLS)
 	@echo "$(OTA_FROM_TARGET_SCRIPT)" > $(PRODUCT_OUT)/ota_script_path
 	@echo "$(override_device)" > $(PRODUCT_OUT)/ota_override_device
@@ -1648,6 +1670,7 @@ $(INTERNAL_OTA_PACKAGE_TARGET): $(BUILT_TARGET_FILES_PACKAGE) $(DISTTOOLS)
            --override_device=$(override_device) $(override_prop) \
 	   $(if $(OEM_OTA_CONFIG), -o $(OEM_OTA_CONFIG)) \
 	   $(BUILT_TARGET_FILES_PACKAGE) $@
+endif	   
 
 .PHONY: otapackage bacon
 otapackage: $(INTERNAL_OTA_PACKAGE_TARGET)


### PR DESCRIPTION
- Rename to BLOCK_BASED_BUILD to be generic

Introduce Bliss Block Build flag

Device tree needs a flag in BoardConfig.mk
1=Block Build
0=No Block Build KK zip style

Change-Id: Ie67aba33c4e087a600f779937764b73887b18cdf

Changes to Bliss Build Block
- Make all CAPS to match other flags
- Set a default to build block style

Change-Id: I83a6180de1fb84d160a5d40d6501c692019704a7
